### PR TITLE
Simplify mod point

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,9 @@ To build the tree, we need the center of mass of each cloud.
 
 */
 pub mod point;
-use point::{Float, Point};
+use point::*;
 use rand::Rng;
 use Tree::*;
-
-static ZERO: Point = Point { x: 0.0, y: 0.0 };
 
 #[derive(Debug)]
 pub struct Mass {
@@ -144,7 +142,7 @@ impl Simulator {
     }
     pub fn step(&mut self) {
         let mut tree = self.tree();
-        tree.update_with(ZERO);
+        tree.update_with(Point::ZERO);
     }
     pub fn tree<'a>(&'a mut self) -> Tree<'a> {
         let mut iter = self.masses.iter_mut();
@@ -163,13 +161,13 @@ mod test {
     #[test]
     fn test_update_with() {
         let mut test_mass = Mass {
-            position: ZERO,
-            velocity: Point { x: 1.0, y: 1.0 },
+            position: Point::ZERO,
+            velocity: Point(1.0, 1.0),
             mass: 1.0,
         };
         let mut test_node = Tree::Leaf(&mut test_mass);
 
-        test_node.update_with(ZERO);
+        test_node.update_with(Point::ZERO);
         println!("test_node is {:?}", test_node);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,21 @@ mod test {
         let mut test_node = Tree::Leaf(&mut test_mass);
 
         test_node.update_with(Point::ZERO);
-        println!("test_node is {:?}", test_node);
+
+        if let Leaf(ref x) = test_node {
+            assert!(x.position.minus(Point(1.0, 1.0)).magnitude_squared() < Point::EPSILON);
+            assert!(x.position == Point(1.0, 1.0));
+        } else {
+            panic!("Not a Leaf() when that is the only choice!!");
+        }
+
+        test_node.update_with(Point(2.0, 3.0));
+
+        if let Leaf(ref x) = test_node {
+            assert!(x.position.minus(Point(4.0, 5.0)).magnitude_squared() < Point::EPSILON);
+            assert!(x.position == Point(4.0, 5.0));
+        } else {
+            panic!("Not a Leaf() when that is the only choice!!");
+        }
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -2,51 +2,82 @@ use rand::Rng;
 
 pub type Float = f64;
 
-#[derive(Debug, Copy, Clone)]
-pub struct Point {
-    pub x: Float,
-    pub y: Float,
-}
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Point(pub Float, pub Float);
 
 impl Point {
+    pub const ZERO: Point = Point(0.0, 0.0);
+    pub const EPSILON: Float = 0.0000001;
+
     pub fn scale(self, s: Float) -> Point {
-        return Point {
-            x: self.x * s,
-            y: self.y * s,
-        };
+        Point(self.0 * s, self.1 * s)
     }
+
     pub fn add(self, that: Point) -> Point {
-        return Point {
-            x: self.x + that.x,
-            y: self.y + that.y,
-        };
+        Point(self.0 + that.0, self.1 + that.1)
     }
+
     pub fn minus(self, that: Point) -> Point {
-        return Point {
-            x: self.x - that.x,
-            y: self.y - that.y,
-        };
+        self.add(that.inverse())
     }
+
     pub fn inverse(self) -> Point {
-        return Point {
-            x: -self.x,
-            y: -self.y,
-        };
+        self.scale(-1.0)
     }
+
     pub fn magnitude_squared(self) -> Float {
-        return self.x * self.x + self.y * self.y;
+        self.0 * self.0 + self.1 * self.1
     }
-    pub fn magnitude(self) -> Float {
-        return self.magnitude_squared().sqrt();
-    }
+
     pub fn unit_vector(self) -> Point {
-        return self.scale(self.magnitude());
+        self.scale(1.0 / self.magnitude_squared().sqrt())
     }
+
     pub fn new_random() -> Point {
         let mut rng = rand::thread_rng();
-        return Point {
-            x: rng.gen::<Float>(),
-            y: rng.gen::<Float>(),
-        };
+        Point(rng.gen::<f64>(), rng.gen::<f64>())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_scale() {
+        assert!(Point(1.0, 1.0).scale(2.0) == Point(2.0, 2.0));
+        assert!(Point(1.0, 1.0).scale(-3.0) == Point(-3.0, -3.0));
+        assert!(Point(1.0, 2.0).scale(-3.0) == Point(-3.0, -6.0));
+        assert!(Point(1.0, 2.0).scale(0.5) == Point(0.5, 1.0));
+    }
+
+    #[test]
+    fn test_add() {
+        assert!(Point(4.0, 5.0).add(Point(1.0, 2.0)) == Point(5.0, 7.0));
+    }
+
+    #[test]
+    fn test_minus() {
+        assert!(Point(4.0, 5.0).minus(Point(1.0, 2.0)) == Point(3.0, 3.0));
+    }
+
+    #[test]
+    fn test_inverse() {
+        assert!(Point(1.0, 2.0).inverse() == Point(-1.0, -2.0));
+    }
+
+    #[test]
+    fn test_magnitude_squared() {
+        assert!(Point(3.0, 4.0).magnitude_squared() == 25.0);
+    }
+
+    #[test]
+    fn test_unit_vector() {
+        assert!((Point::new_random().unit_vector().magnitude_squared() - 1.0) < Point::EPSILON);
+    }
+
+    #[test]
+    fn test_random() {
+        assert!(Point::new_random() != Point::new_random());
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -29,6 +29,10 @@ impl Point {
         self.0 * self.0 + self.1 * self.1
     }
 
+    pub fn magnitude(self) -> Float {
+        self.magnitude_squared().sqrt()
+    }
+
     pub fn unit_vector(self) -> Point {
         self.scale(1.0 / self.magnitude_squared().sqrt())
     }
@@ -69,6 +73,11 @@ mod test {
     #[test]
     fn test_magnitude_squared() {
         assert!(Point(3.0, 4.0).magnitude_squared() == 25.0);
+    }
+
+    #[test]
+    fn test_magnitude() {
+        assert!(Point(3.0, 4.0).magnitude() == 5.0);
     }
 
     #[test]


### PR DESCRIPTION
Change mod point from using a struct Point with named fields to a more
simple tuple.  Also move the definition of ZERO to be an associated
const of struct Point -- this is useful in case we have ZERO values from
another module someday.

Also added unit tests for mod point.  All tests currently pass.  Due to the
nature of floating-point numbers, some tests are validated to within a
specified EPSILON value (also an associated const of struct Point).