### PR TITLE
Fix update_with velocity calculation on Leaf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ impl<'a> Tree<'a> {
                 i.right.update_with(force.add(f.inverse()));
             }
             Leaf(mass) => {
-                mass.velocity.add(force.scale(1.0 / mass.mass));
+                mass.velocity = mass.velocity.add(force.scale(1.0 / mass.mass));
                 mass.position = mass.position.add(mass.velocity);
             }
         }


### PR DESCRIPTION
Fix to actually store the resulting updated velocity in update_with().
Previous version did the calculation using the add() method, and then
threw it away.